### PR TITLE
[4diac] Add 4diac documentation to the user manual

### DIFF
--- a/user_manual/sections/4diac.tex
+++ b/user_manual/sections/4diac.tex
@@ -1,0 +1,77 @@
+
+\let\svus\_
+\newcommand\newuson{\def\_{\svus\allowbreak\hspace{0pt}}}
+\newcommand\newusoff{\let\_\svus}
+\newuson
+
+\subsubsection{About 4diac}\label{sec:simulators:4diac:about4diac}
+
+4diac provides an open source infrastructure for distributed industrial process measurement and control systems based on the IEC 61499 standard. IEC 61499 defines a domain-specific
+modeling language for developing distributed industrial control solutions. IEC 61499 extends IEC 61131-1 by improving the encapsulation of software components for increased re-usability, 
+providing a vendor-independent format, and simplifying support for controller to controller communication. Its distribution functionality and the inherent support for dynamic reconfiguration 
+provide the required infrastructure for Industrie 4.0 and industrial IoT applications.
+
+The 4DIAC framework allows the development of distributed control systems compliant to the IEC 61499 standard and two of its main projects are:
+
+\begin{itemize}
+  \item 4DIAC-RTE (FORTE): The runtime environment is a small portable C++ implementation of an IEC 61499 runtime environment, which supports the execution of distributed control programs 
+  on small embedded devices. FORTE runs above a device's OS. It is a multi-threaded and less memory consuming runtime environment. The runtime environment has been tested on the following systems:
+  \begin{itemize}
+    \item Windows Cygwin on i386, ppc and xScale
+    \item Linux on i386, ppc and xScale
+    \item NetOS
+    \item RTOS on IPC@chip
+    \item eCos ARM7
+    \item VxWorks
+  \end{itemize}     
+  \item 4DIAC-IDE: This is the IDE (Integrated Development Environment) written in Java and based on the Eclipse framework and provides an extensible engineering environment for modeling 
+  distributed control applications compliant to the IEC 61499 standard. You use 4DIAC to create FBs, applications, configure the devices and all related to IEC 61499 and also download this 
+  to devices running FORTE.
+\end{itemize}
+
+4DIAC has the capability to export each device of a system as an FMU (FMI 2.0) in order to test the behaviour of the controller against another FMU of the controlled system in 
+the co-simulation environment. 
+
+\subsubsection{How to export and FMU in 4DIAC?}\label{sec:simulators:4diac:exportFMU}
+
+The following explanation should be done after having some experience compiling forte from source code. The following link should be followed for a better understanding:
+
+\begin{quote}
+  \url{http://www.eclipse.org/4diac/documentation/html/installation/install.html#ownFORTE}
+\end{quote}
+
+\begin{itemize}
+    \item First, a special 4diac-rte has to be compiled, as explained in the link above. Follow the steps to build your own FBs as in the documentation 
+    on the webpage. In step 3 where the features to be compiled are selected, select also FORTE\_ENABLE\_FMU. The FORTE\_FMU\_INCLUDE variable should be set to the path where the headers files 
+    from the fmi standard are located. This will generate a dynamic library, whose name will depend on the operative system forte was compiled. This library must be renamed to one of the following 
+    supported ones: win32Forte.dll, win64Forte.dll, linux32Forte.so or linux64Forte.so (for Windows 32 bits, Windows 64 bits, Linux 32 bits and Linux 64 bits operative systems respectively). 
+    An FMU can have many different libraries, which will allow the FMU to be simulated in these Operative Systems.
+    \item In the 4DIAC-IDE, go to Windows $\rightarrow$ Preferences $\rightarrow$ 4DIAC $\rightarrow$ FMU Preferences and in the "Binaries Location" field, select the path where the compiled forte (with the right new name) 
+    is located. Many libraries from the different OS can be placed in the same folder, which will be detected by the preference page, enabling the OS to be possibly included in the FMUs.
+     Apply the changes and close.
+    \item Go to File $\rightarrow$ Export... $\rightarrow$ 4diac $\rightarrow$ Create FMU $\rightarrow$ Next. In the tree of projects, select the Devices with the resources to be exported as FMU. Remember, one FMU for each device will be 
+    exported. Choose the directory to export the FMU and the libraries to be included (only the libraries found in the step before will be enabled to be selected). The last option allows the user to 
+    save the selected libraries for the next time. Click Finish and it's done.
+\end{itemize}
+
+\subsubsection{Notes}\label{sec:simulators:4diac:notes}
+
+\begin{itemize}
+  \item The IX and QX FBs are treated as boolean inputs and outputs respectively of the FMU.
+  \item The IW and QW FBs are treated as integer inputs and outputs respectively of the FMU.
+  \item Literals in data inputs are treated as parameters of the FMU.
+  \item Types BYTE, WORD, DWORD, LWORD, INT, DINT, LINT, SINT, USINT, UINT, UDINT, ULINT, ANY\_INT are treated as integers in the FMU.
+  \item Types STRING, WSTRING, ANY\_STRING, DATE, DATE\_AND\_TIME, TIME\_OF\_DAY, ANY\_DATE, TIME are treated as strings in the FMU.
+  \item Types REAL, LREAL, ANY\_REAL are treated as real in the FMU.
+  \item Type BOOL is treated as boolean in the FMU.
+  \item Data inputs and outputs which are defined to abstract types (not any of the above) are not included in the FMU
+  \item Communication FBs are also treated as inputs and outputs of the FMU if the PARAM data input is set to "fmu[]". Each SD and RD is treated as an output and input respectively.
+  \item All the data inputs and data outputs, as well as internal variables in basic function blocks (and the current state of the ECC), and internal FBs in a composite FB are exported as 
+  internal variables of the FMU, meaning that can be monitored when co-simulating. The number of time an event has been triggered is also available. Service Function Blocks have only their 
+  interface available since the implementation is hidden.
+  \item The FBs: E\_CYCLE, E\_F\_TRIG, E\_R\_TRIG, E\_TimeOut, E\_CTU, E\_D\_FF, E\_DEMUX, E\_MERGE, E\_PERMIT, E\_REND, E\_RS, E\_SELECT, E\_SPLIT, E\_SR, E\_SWITCH are treated as Service Function Blocks.
+  \item Adapters are not yet supported.
+\end{itemize}
+
+
+\newusoff

--- a/user_manual/sections/separatetools.tex
+++ b/user_manual/sections/separatetools.tex
@@ -200,3 +200,7 @@ The generated FMU will be saved to \texttt{\%{}TEMP\%{}\textbackslash{}OpenModel
 \clearpage
 \subsection{AutoFOCUS3}\label{sec:simulators:autofocus3}
 \input{sections/autofocus.tex}
+
+\clearpage
+\subsection{4DIAC}\label{sec:simulators:4diac}
+\input{sections/4diac.tex}


### PR DESCRIPTION
This PR adds tex files of the 4diac documentation for the user manual. I had problems exporting to a pdf file. So I open this PR to check if my changes break anything in the project, and ask, if merged, if someone could generate the PDF from it.